### PR TITLE
fix project structure

### DIFF
--- a/sibyl/__init__.py
+++ b/sibyl/__init__.py
@@ -1,5 +1,5 @@
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
-from sibyl.src import execute
+import execute
 modules = [
     'execute'
     ]


### PR DESCRIPTION
There is no folder named `src`. The dependencies that `__init__.py` looks for are inside the `sibyl` folder, and `setup.py` requires `__init__.py`  to be inside the `sibyl` folder.